### PR TITLE
Fix undefined names

### DIFF
--- a/qpid/connection08.py
+++ b/qpid/connection08.py
@@ -24,6 +24,7 @@ server, or even a proxy implementation.
 """
 
 import socket, codec, errno, qpid
+from abc import abstractmethod
 from cStringIO import StringIO
 from codec import EOF
 from compat import SHUT_RDWR
@@ -335,9 +336,13 @@ class Frame:
     self.bof = True
     self.eof = True
 
-  def encode(self, enc): abstract
+  @abstractmethod
+  def encode(self, enc):
+      pass
 
-  def decode(spec, dec, size): abstract
+  @abstractmethod
+  def decode(spec, dec, size):
+      pass
 
 class Method(Frame):
 

--- a/qpid/datatypes.py
+++ b/qpid/datatypes.py
@@ -292,7 +292,7 @@ except ImportError:
   class UUID:
     def __init__(self, hex=None, bytes=None):
       if [hex, bytes].count(None) != 1:
-        raise TypeErrror("need one of hex or bytes")
+        raise TypeError("need one of hex or bytes")
       if bytes is not None:
         self.bytes = bytes
       elif hex is not None:

--- a/qpid/debug.py
+++ b/qpid/debug.py
@@ -40,10 +40,10 @@ class LoudLock:
     while not self.lock.acquire(blocking=0):
       time.sleep(1)
       print >> sys.out, "TRYING"
-      traceback.print_stack(None, None, out)
+      traceback.print_stack(None, None, sys.out)
       print >> sys.out, "TRYING"
     print >> sys.out, "ACQUIRED"
-    traceback.print_stack(None, None, out)
+    traceback.print_stack(None, None, sys.out)
     print >> sys.out, "ACQUIRED"
     return True
 
@@ -52,4 +52,3 @@ class LoudLock:
 
   def release(self):
     self.lock.release()
-

--- a/qpid/framer.py
+++ b/qpid/framer.py
@@ -22,6 +22,7 @@ from exceptions import Closed
 from packer import Packer
 from threading import RLock
 from logging import getLogger
+from qpid.sasl import SASLError
 
 raw = getLogger("qpid.io.raw")
 frm = getLogger("qpid.io.frm")

--- a/qpid/managementdata.py
+++ b/qpid/managementdata.py
@@ -750,7 +750,7 @@ class ManagementData:
   def do_call (self, data):
     encTokens = data.split ()
     try:
-      tokens = [a.decode(locale.getpreferredencoding()) for a in encArgs]
+      tokens = [a.decode(locale.getpreferredencoding()) for a in encTokens]
     except:
       tokens = encTokens
     if len (tokens) < 2:

--- a/qpid/packer.py
+++ b/qpid/packer.py
@@ -18,12 +18,17 @@
 #
 
 import struct
+from abc import abstractmethod
 
 class Packer:
 
-  def read(self, n): abstract
+  @abstractmethod
+  def read(self, n):
+      pass
 
-  def write(self, s): abstract
+  @abstractmethod
+  def write(self, s):
+      pass
 
   def unpack(self, fmt):
     values = struct.unpack(fmt, self.read(struct.calcsize(fmt)))

--- a/qpid/saslmech/scram.py
+++ b/qpid/saslmech/scram.py
@@ -19,7 +19,7 @@
 
 from hmac import HMAC
 from binascii import b2a_hex
-from sasl import Sasl
+from sasl import Sasl, SaslException
 import os
 import base64
 

--- a/qpid/spec08.py
+++ b/qpid/spec08.py
@@ -475,7 +475,7 @@ def find_rules(node, rules):
 
 def load_rules(specfile):
   rules = []
-  find_rules(xmlutil.parse(specfile), rules)
+  find_rules(mllib.xml_parse(specfile), rules)
   return rules
 
 def test_summary():

--- a/qpid/tests/__init__.py
+++ b/qpid/tests/__init__.py
@@ -59,4 +59,4 @@ class TestTestsXXX(Test):
   def testQuxFail(self):
     import sys
     sys.stdout.write("this test has output with no newline")
-    fdsa
+    fdsa  # noqa  It is supposed to fail

--- a/qpid_tests/broker_0_10/management.py
+++ b/qpid_tests/broker_0_10/management.py
@@ -20,6 +20,7 @@
 from qpid.datatypes import Message, RangedSet
 from qpid.testlib import TestBase010
 from qpid.management import managementChannel, managementClient
+from qpid.queue import Empty
 from threading import Condition
 from time import sleep
 import qmf.console
@@ -723,4 +724,3 @@ class ManagementTest (TestBase010):
             assert(False)
         self.assertEqual("def", msg.content)
         self.assertEqual(False, "x-amqp-0-10.timestamp" in msg.properties)
-


### PR DESCRIPTION
$ __python2 -m flake8 --count --show-source --statistics --select=E901,E999,F821,F822,F823__
```
./qpid_tests/broker_0_10/management.py:699:16: F821 undefined name 'Empty'
        except Empty:
               ^
./qpid_tests/broker_0_10/management.py:722:16: F821 undefined name 'Empty'
        except Empty:
               ^
./qpid/connection08.py:338:26: F821 undefined name 'abstract'
  def encode(self, enc): abstract
                         ^
./qpid/connection08.py:340:32: F821 undefined name 'abstract'
  def decode(spec, dec, size): abstract
                               ^
./qpid/managementdata.py:753:66: F821 undefined name 'encArgs'
      tokens = [a.decode(locale.getpreferredencoding()) for a in encArgs]
                                                                 ^
./qpid/spec08.py:478:14: F821 undefined name 'xmlutil'
  find_rules(xmlutil.parse(specfile), rules)
             ^
./qpid/packer.py:24:22: F821 undefined name 'abstract'
  def read(self, n): abstract
                     ^
./qpid/packer.py:26:23: F821 undefined name 'abstract'
  def write(self, s): abstract
                      ^
./qpid/datatypes.py:295:15: F821 undefined name 'TypeErrror'
        raise TypeErrror("need one of hex or bytes")
              ^
./qpid/debug.py:43:41: F821 undefined name 'out'
      traceback.print_stack(None, None, out)
                                        ^
./qpid/debug.py:46:39: F821 undefined name 'out'
    traceback.print_stack(None, None, out)
                                      ^
./qpid/framer.py:56:16: F821 undefined name 'SASLError'
        except SASLError, e:
               ^
./qpid/framer.py:99:18: F821 undefined name 'SASLError'
          except SASLError, e:
                 ^
./qpid/saslmech/scram.py:48:15: F821 undefined name 'SaslException'
        raise SaslException("Server nonce does not start with client nonce")
              ^
./qpid/saslmech/scram.py:90:13: F821 undefined name 'SaslException'
      raise SaslException("Server verification failed")
            ^
./qpid/tests/__init__.py:62:5: F821 undefined name 'fdsa'
    fdsa
    ^
16    F821 undefined name 'abstract'
16
```
