### PR TITLE
QPID-7070: add flake8 to CI as first step towards PEP-8, fix some most egregious things reported

### DIFF
--- a/qpid/connection08.py
+++ b/qpid/connection08.py
@@ -341,9 +341,9 @@ class Frame:
     self.bof = True
     self.eof = True
 
-  def encode(self, enc): abstract
+  def encode(self, enc): abstract  # pylint: disable=F821
 
-  def decode(spec, dec, size): abstract
+  def decode(spec, dec, size): abstract  # pylint: disable=F821
 
 class Method(Frame):
 

--- a/qpid/connection08.py
+++ b/qpid/connection08.py
@@ -341,9 +341,9 @@ class Frame:
     self.bof = True
     self.eof = True
 
-  def encode(self, enc): abstract  # pylint: disable=F821
+  def encode(self, enc): abstract  # noqa: F821
 
-  def decode(spec, dec, size): abstract  # pylint: disable=F821
+  def decode(spec, dec, size): abstract  # noqa: F821
 
 class Method(Frame):
 

--- a/qpid/datatypes.py
+++ b/qpid/datatypes.py
@@ -293,7 +293,7 @@ except ImportError:
   class UUID:
     def __init__(self, hex=None, bytes=None):
       if [hex, bytes].count(None) != 1:
-        raise TypeErrror("need one of hex or bytes")
+        raise TypeError("need one of hex or bytes")
       if bytes is not None:
         self.bytes = bytes
       elif hex is not None:

--- a/qpid/debug.py
+++ b/qpid/debug.py
@@ -42,10 +42,10 @@ class LoudLock:
     while not self.lock.acquire(blocking=0):
       time.sleep(1)
       print("TRYING", file=sys.out)
-      traceback.print_stack(None, None, out)
+      traceback.print_stack(None, None, sys.out)
       print("TRYING", file=sys.out)
     print("ACQUIRED", file=sys.out)
-    traceback.print_stack(None, None, out)
+    traceback.print_stack(None, None, sys.out)
     print("ACQUIRED", file=sys.out)
     return True
 

--- a/qpid/framer.py
+++ b/qpid/framer.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 import struct, socket
 from .exceptions import Closed
 from .packer import Packer
+from .sasl import SASLError
 from threading import RLock
 from logging import getLogger
 

--- a/qpid/packer.py
+++ b/qpid/packer.py
@@ -22,9 +22,9 @@ import struct
 
 class Packer:
 
-  def read(self, n): abstract  # pylint: disable=F821
+  def read(self, n): abstract  # noqa: F821
 
-  def write(self, s): abstract  # pylint: disable=F821
+  def write(self, s): abstract  # noqa: F821
 
   def unpack(self, fmt):
     values = struct.unpack(fmt, self.read(struct.calcsize(fmt)))

--- a/qpid/packer.py
+++ b/qpid/packer.py
@@ -22,9 +22,9 @@ import struct
 
 class Packer:
 
-  def read(self, n): abstract
+  def read(self, n): abstract  # pylint: disable=F821
 
-  def write(self, s): abstract
+  def write(self, s): abstract  # pylint: disable=F821
 
   def unpack(self, fmt):
     values = struct.unpack(fmt, self.read(struct.calcsize(fmt)))

--- a/qpid/saslmech/scram.py
+++ b/qpid/saslmech/scram.py
@@ -20,7 +20,7 @@
 from __future__ import absolute_import
 from hmac import HMAC
 from binascii import b2a_hex
-from .sasl import Sasl
+from .sasl import Sasl, SaslException
 import os
 import base64
 

--- a/qpid/tests/__init__.py
+++ b/qpid/tests/__init__.py
@@ -61,4 +61,4 @@ class TestTestsXXX(Test):
   def testQuxFail(self):
     import sys
     sys.stdout.write("this test has output with no newline")
-    fdsa
+    fdsa  # pylint: disable=F821

--- a/qpid/tests/__init__.py
+++ b/qpid/tests/__init__.py
@@ -61,4 +61,4 @@ class TestTestsXXX(Test):
   def testQuxFail(self):
     import sys
     sys.stdout.write("this test has output with no newline")
-    fdsa  # pylint: disable=F821
+    fdsa  # noqa: F821

--- a/qpid_tests/broker_0_10/management.py
+++ b/qpid_tests/broker_0_10/management.py
@@ -25,6 +25,7 @@ from threading import Condition
 from time import sleep
 import qmf.console
 import qpid.messaging
+from qpid.messaging.exceptions import Empty
 from qpidtoollibs import BrokerAgent
 
 class ManagementTest (TestBase010):


### PR DESCRIPTION
https://github.com/jiridanek/qpid-python/actions/runs/4652820540/jobs/8233256030#step:9:21

These look like real bugs, but, the code worked ok with them, so I am not sure there is a point in messing with it. Anyways, this PR does just that, where it seems easy.

```
./qpid/datatypes.py:295:15: F821 undefined name 'TypeErrror'
        raise TypeErrror("need one of hex or bytes")
              ^
./qpid/debug.py:43:41: F821 undefined name 'out'
      traceback.print_stack(None, None, out)
                                        ^
./qpid/debug.py:46:39: F821 undefined name 'out'
    traceback.print_stack(None, None, out)
                                      ^
./qpid/saslmech/scram.py:48:15: F821 undefined name 'SaslException'
        raise SaslException("Server nonce does not start with client nonce")
              ^
./qpid/saslmech/scram.py:90:13: F821 undefined name 'SaslException'
      raise SaslException("Server verification failed")
            ^
./qpid_tests/broker_0_10/management.py:699:16: F821 undefined name 'Empty'
        except Empty:
               ^
./qpid_tests/broker_0_10/management.py:722:16: F821 undefined name 'Empty'
        except Empty:
               ^
```

No idea what to do with this. That `xmlutil` is nowhere to be found. Except maybe https://pypi.org/project/xmlutil/. It is not imported, though. Anyways, it does not matter for qpid-cpp, so maybe let's ignore it.

```
./qpid/spec08.py:478:14: F821 undefined name 'xmlutil'
  find_rules(xmlutil.parse(specfile), rules)
             ^
```

These look intentional. First, cause NameError in a test, and the four afterwards will blow up if anyone calls the method without overriding the abstract implementation, I guess.

```
./qpid/tests/__init__.py:62:5: F821 undefined name 'fdsa'
    fdsa
    ^

./qpid/connection08.py:338:26: F821 undefined name 'abstract'
  def encode(self, enc): abstract
                         ^
./qpid/connection08.py:340:32: F821 undefined name 'abstract'
  def decode(spec, dec, size): abstract
                               ^
./qpid/packer.py:24:22: F821 undefined name 'abstract'
  def read(self, n): abstract
                     ^
./qpid/packer.py:26:23: F821 undefined name 'abstract'
  def write(self, s): abstract
                      ^
```