### PR TITLE
QPID-8632: use absolute, full imports when dealing with circular imports

### DIFF
--- a/mllib/dom.py
+++ b/mllib/dom.py
@@ -25,7 +25,7 @@ from __future__ import division
 from __future__ import generators
 from __future__ import nested_scopes
 
-import transforms
+import mllib.transforms
 
 class Container:
 
@@ -109,7 +109,7 @@ class Node(Container, Component, Dispatcher):
       return nd
 
   def text(self):
-    return self.dispatch(transforms.Text())
+    return self.dispatch(mllib.transforms.Text())
 
   def tag(self, name, *attrs, **kwargs):
     t = Tag(name, *attrs, **kwargs)

--- a/mllib/transforms.py
+++ b/mllib/transforms.py
@@ -21,7 +21,7 @@
 Useful transforms for dom objects.
 """
 
-import dom
+import mllib.dom
 from cStringIO import StringIO
 
 class Visitor:
@@ -45,12 +45,12 @@ class Identity:
     return result
 
   def default(self, tag):
-    result = dom.Tag(tag.name, *tag.attrs)
+    result = mllib.dom.Tag(tag.name, *tag.attrs)
     result.extend(self.descend(tag))
     return result
 
   def tree(self, tree):
-    result = dom.Tree()
+    result = mllib.dom.Tree()
     result.extend(self.descend(tree))
     return result
 

--- a/qpid/connection.py
+++ b/qpid/connection.py
@@ -26,7 +26,7 @@ from session import Session
 from generator import control_invoker
 from exceptions import *
 from logging import getLogger
-import delegates, socket
+import qpid.delegates, socket
 import sys
 
 class ChannelBusy(Exception): pass
@@ -38,10 +38,10 @@ class SessionBusy(Exception): pass
 class ConnectionFailed(Exception): pass
 
 def client(*args, **kwargs):
-  return delegates.Client(*args, **kwargs)
+  return qpid.delegates.Client(*args, **kwargs)
 
 def server(*args, **kwargs):
-  return delegates.Server(*args, **kwargs)
+  return qpid.delegates.Server(*args, **kwargs)
 
 from framer import Framer
 

--- a/qpid/delegates.py
+++ b/qpid/delegates.py
@@ -17,7 +17,8 @@
 # under the License.
 #
 
-import os, connection, session
+import os, session
+import qpid.connection
 from util import notify, get_client_properties_with_defaults
 from datatypes import RangedSet
 from exceptions import VersionError, Closed
@@ -37,7 +38,7 @@ class Delegate:
   def received(self, op):
     ssn = self.connection.attached.get(op.channel)
     if ssn is None:
-      ch = connection.Channel(self.connection, op.channel)
+      ch = qpid.connection.Channel(self.connection, op.channel)
     else:
       ch = ssn.channel
 
@@ -66,9 +67,9 @@ class Delegate:
     try:
       self.connection.attach(a.name, ch, self.delegate, a.force)
       ch.session_attached(a.name)
-    except connection.ChannelBusy:
+    except qpid.connection.ChannelBusy:
       ch.session_detached(a.name)
-    except connection.SessionBusy:
+    except qpid.connection.SessionBusy:
       ch.session_detached(a.name)
 
   def session_attached(self, ch, a):
@@ -122,7 +123,7 @@ class Server(Delegate):
     self.connection.read_header()
     # XXX
     self.connection.write_header(0, 10)
-    connection.Channel(self.connection, 0).connection_start(mechanisms=["ANONYMOUS"])
+    qpid.connection.Channel(self.connection, 0).connection_start(mechanisms=["ANONYMOUS"])
 
   def connection_start_ok(self, ch, start_ok):
     ch.connection_tune(channel_max=65535)


### PR DESCRIPTION
This patch leaves the circular import in place, but changes the importing code to make it overall safer.