### PR TITLE
QPID-8631: remove use of `iteritems` and `xrange`

### DIFF
--- a/qpid/client.py
+++ b/qpid/client.py
@@ -121,7 +121,7 @@ class Client:
     self.lock.acquire()
     try:
       id = None
-      for i in xrange(1, 64*1024):
+      for i in range(1, 64*1024):
         if not self.sessions.has_key(i):
           id = i
           break

--- a/qpid/connection.py
+++ b/qpid/connection.py
@@ -111,7 +111,7 @@ class Connection(Framer):
       self.lock.release()
 
   def __channel(self):
-    for i in xrange(1, self.channel_max):
+    for i in range(1, self.channel_max):
       if not self.attached.has_key(i):
         return i
     else:

--- a/qpid/datatypes.py
+++ b/qpid/datatypes.py
@@ -319,7 +319,7 @@ except ImportError:
   rand = random.Random()
   rand.seed((os.getpid(), time.time(), socket.gethostname()))
   def random_uuid():
-    bytes = [rand.randint(0, 255) for i in xrange(16)]
+    bytes = [rand.randint(0, 255) for i in range(16)]
 
     # From RFC4122, the version bits are set to 0100
     bytes[7] &= 0x0F

--- a/qpid/messaging/driver.py
+++ b/qpid/messaging/driver.py
@@ -894,7 +894,7 @@ class Engine:
     if ssn.closed: return
     sst = self._attachments.get(ssn)
     if sst is None:
-      for i in xrange(0, self.channel_max):
+      for i in range(0, self.channel_max):
         if not self._sessions.has_key(i):
           ch = i
           break

--- a/qpid/messaging/endpoints.py
+++ b/qpid/messaging/endpoints.py
@@ -180,7 +180,7 @@ class Connection(Endpoint):
     for key in opt_keys:
         setattr(self, key, None)
     # Get values from options, check for invalid options
-    for (key, value) in options.iteritems():
+    for (key, value) in options.items():
         if key in opt_keys:
             setattr(self, key, value)
         else:

--- a/qpid/peer.py
+++ b/qpid/peer.py
@@ -271,7 +271,7 @@ class Channel:
         # if other type
         raise ContentError("Content body must be string or buffer, not a %s" % type(content.body))
       frame_max = self.client.tune_params['frame_max'] - self.client.conn.AMQP_HEADER_SIZE
-      for chunk in (content.body[i:i + frame_max] for i in xrange(0, len(content.body), frame_max)):
+      for chunk in (content.body[i:i + frame_max] for i in range(0, len(content.body), frame_max)):
         self.write(Body(chunk))
 
   def receive(self, frame, work):

--- a/qpid/tests/codec.py
+++ b/qpid/tests/codec.py
@@ -637,7 +637,7 @@ def test(type, value):
     enc = stream.getvalue()
     stream.reset()
     dup = []
-    for i in xrange(len(values)):
+    for i in range(len(values)):
       dup.append(codec.decode(type))
     if values != dup:
       raise AssertionError("%r --> %r --> %r" % (values, enc, dup))

--- a/qpid/tests/datatypes.py
+++ b/qpid/tests/datatypes.py
@@ -210,7 +210,7 @@ class UUIDTest(TestCase):
     # this test is kind of lame, but it does excercise the basic
     # functionality of the class
     u = uuid4()
-    for i in xrange(1024):
+    for i in range(1024):
       assert u != uuid4()
 
 class MessageTest(TestCase):

--- a/qpid/tests/messaging/endpoints.py
+++ b/qpid/tests/messaging/endpoints.py
@@ -82,7 +82,7 @@ class SetupTests(Base):
     try:
       for i in range(32):
         if fds: os.close(fds.pop())
-      for i in xrange(64):
+      for i in range(64):
         conn = Connection.establish(self.broker, **self.connection_options())
         conn.close()
     finally:
@@ -94,7 +94,7 @@ class SetupTests(Base):
     try:
       for i in range(32):
         if fds: os.close(fds.pop())
-      for i in xrange(64):
+      for i in range(64):
         conn = Connection("localhost:0", **self.connection_options())
         # XXX: we need to force a waiter to be created for this test
         # to work

--- a/qpid_tests/broker_0_10/lvq.py
+++ b/qpid_tests/broker_0_10/lvq.py
@@ -73,7 +73,7 @@ class LVQTests (Base):
             counters[k] += 1
             messages.append(create_message(k, "%s-%i" % (k, counters[k])))
         # make sure we have sent at least one message for every key
-        for k, v in counters.iteritems():
+        for k, v in counters.items():
             if v == 0:
                 counters[k] += 1
                 messages.append(create_message(k, "%s-%i" % (k, counters[k])))

--- a/qpid_tests/broker_0_9/queue.py
+++ b/qpid_tests/broker_0_9/queue.py
@@ -121,7 +121,7 @@ class QueueTests(TestBase):
         channel.queue_declare(queue=queue_name, arguments={"x-qpid-capacity" : 25, "x-qpid-flow-resume-capacity" : 15})
 
         try:
-            for i in xrange(100):
+            for i in range(100):
                 channel.basic_publish(exchange="", routing_key=queue_name,
                                       content=Content("This is a message with more than 25 bytes. This should trigger flow control."))
                 time.sleep(.1)


### PR DESCRIPTION
These are somewhat helpful in Python 2, but they are not available in Python 3.