### PR TITLE
QPID-8170: fix qpid-python-test discovery broken by commit 85348b01

### DIFF
--- a/qpid-python-test
+++ b/qpid-python-test
@@ -22,6 +22,8 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+
+import importlib
 import logging, optparse, os, struct, sys, time, traceback, types
 from fnmatch import fnmatchcase as match
 from getopt import GetoptError
@@ -532,7 +534,19 @@ class ModuleScanner:
     names = dir(obj)
     names.sort()
     for name in names:
-      yield getattr(obj, name)
+      child = getattr(obj, name)
+      if type(child) is not types.ModuleType:
+        yield child
+      else:
+        # import the submodule of the given name afresh
+        absname = "%s.%s" % (obj.__name__, name)
+        try:
+          yield importlib.import_module(absname)
+        except ImportError:
+          # if module m imports module n, then we end up trying to import module m.n, which does not exist
+          # therefore fail only if the import we tried looks very reasonable but it still did not succeed
+          if absname == child.__name__:
+            raise
 
   def extract(self, obj):
     # the None is required for older versions of python


### PR DESCRIPTION
The problem stems from the way the testcode imports the production code, so that when both have a module of the same name, the test runner descends into the production code when discovering tests, instead of into the test code.

```
{code:title=qpid/tests/messaging/__init__.py}
from qpid.tests.messaging.implementation import *

[...]

from . import address, endpoints, message, selector
{code}

The file imported on the first line contains

{code:title=qpid/tests/messaging/implementation.py}
from qpid.messaging import *
{code}
```

and {{qpid.messaging}} contains its own {{address.py}} submodule.

Therefore, when {{qpid-test-runner}} tries to access {{qpid.tests.messaging.mesage}}, it actually gets {{qpid.messaging.message}}, which was imported first. But that does not contain any tests, and the message tests are missed and never executed.

This only started happening after my relative imports modernizing commit https://github.com/apache/qpid-python/commit/9651001c6fe0b65e538a96e27df36582b7ccb004.

Before, Totals: 349 tests, 349 passed, 0 skipped, 0 ignored, 0 failed and Totals: 678 tests, 585 passed, 93 skipped, 0 ignored, 0 failed (https://github.com/apache/qpid-python/actions/runs/4661323947/jobs/8250463871)

After, Totals: 218 tests, 218 passed, 0 skipped, 0 ignored, 0 failed and Totals: 547 tests, 454 passed, 93 skipped, 0 ignored, 0 failed (https://github.com/apache/qpid-python/actions/runs/4661535006/jobs/8250915935)