### PR TITLE
QPID-8631: make package version string in setup.py compliant with PEP-440

### DIFF
--- a/qpid_tests/__init__.py
+++ b/qpid_tests/__init__.py
@@ -19,4 +19,5 @@
 # under the License.
 #
 
-import broker_1_0, broker_0_10, broker_0_9, broker_0_8
+from __future__ import absolute_import
+from . import broker_1_0, broker_0_10, broker_0_9, broker_0_8

--- a/qpid_tests/broker_1_0/__init__.py
+++ b/qpid_tests/broker_1_0/__init__.py
@@ -19,8 +19,9 @@
 # under the License.
 #
 
-from general import *
-from legacy_exchanges import *
-from selector import *
-from translation import *
-from tx import *
+from __future__ import absolute_import
+from .general import *
+from .legacy_exchanges import *
+from .selector import *
+from .translation import *
+from .tx import *

--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,7 @@ class install_lib(_install_lib):
 scripts = ["qpid-python-test", "qpid-python-test.bat"]
 
 setup(name="qpid-python",
-      version="1.38.0-SNAPSHOT",
+      version="1.38.0.dev0+SNAPSHOT",
       author="Apache Qpid",
       author_email="users@qpid.apache.org",
       packages=["mllib", "qpid", "qpid.messaging", "qpid.tests",


### PR DESCRIPTION
Contemporary versions of setuptools and pip will bork at misformatted version strings and refuse to install the package.